### PR TITLE
Separate Migrations

### DIFF
--- a/src/database/migration/development/1587051617754-MainMigration.ts
+++ b/src/database/migration/development/1587051617754-MainMigration.ts
@@ -1,13 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 import { Cohort, Canon, Parent, Child, Stories, Illustrations } from '../../../database/entity';
-import {
-    CohortSeed,
-    CanonSeed,
-    ParentSeed,
-    ChildSeed,
-    StorySeed,
-    IllustrationSeed,
-} from './seeds/seeds';
+import { CohortSeed, CanonSeed, ParentSeed, ChildSeed, StorySeed, IllustrationSeed } from './seeds';
 import Stripe from 'stripe';
 
 export class MainMigration1587051617754 implements MigrationInterface {

--- a/src/database/migration/development/1587051617754-MainMigration.ts
+++ b/src/database/migration/development/1587051617754-MainMigration.ts
@@ -1,5 +1,5 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
-import { Cohort, Canon, Parent, Child, Stories, Illustrations } from '../../database/entity';
+import { Cohort, Canon, Parent, Child, Stories, Illustrations } from '../../../database/entity';
 import {
     CohortSeed,
     CanonSeed,
@@ -7,7 +7,7 @@ import {
     ChildSeed,
     StorySeed,
     IllustrationSeed,
-} from '../seeds/seeds';
+} from './seeds/seeds';
 import Stripe from 'stripe';
 
 export class MainMigration1587051617754 implements MigrationInterface {

--- a/src/database/migration/development/seeds.ts
+++ b/src/database/migration/development/seeds.ts
@@ -1,9 +1,9 @@
-import { Cohort, Canon, Parent, Child, Stories, Illustrations } from '../../../entity';
-import { DueDates } from '../../../entity/DueDates';
+import { Cohort, Canon, Parent, Child, Stories, Illustrations } from '../../entity';
+import { DueDates } from '../../entity/DueDates';
 import { hashSync } from 'bcryptjs';
-import { Preferences } from '../../../entity/Preferences';
-import { Pages, Transcribed_Pages } from '../../../entity/Pages';
-import { Progress } from '../../../entity/Progress';
+import { Preferences } from '../../entity/Preferences';
+import { Pages, Transcribed_Pages } from '../../entity/Pages';
+import { Progress } from '../../entity/Progress';
 
 /* Non-Nullable vars and columns with no default function MUST be defined  */
 

--- a/src/database/migration/development/seeds/seeds.ts
+++ b/src/database/migration/development/seeds/seeds.ts
@@ -1,9 +1,9 @@
-import { Cohort, Canon, Parent, Child, Stories, Illustrations } from '../entity';
-import { DueDates } from '../entity/DueDates';
+import { Cohort, Canon, Parent, Child, Stories, Illustrations } from '../../../entity';
+import { DueDates } from '../../../entity/DueDates';
 import { hashSync } from 'bcryptjs';
-import { Preferences } from '../entity/Preferences';
-import { Pages, Transcribed_Pages } from '../entity/Pages';
-import { Progress } from '../entity/Progress';
+import { Preferences } from '../../../entity/Preferences';
+import { Pages, Transcribed_Pages } from '../../../entity/Pages';
+import { Progress } from '../../../entity/Progress';
 
 /* Non-Nullable vars and columns with no default function MUST be defined  */
 

--- a/src/ormconfig.ts
+++ b/src/ormconfig.ts
@@ -28,8 +28,8 @@ module.exports = [
     {
         name: 'development',
         type: 'postgres',
-        host: 'localhost',
-        port: 5432,
+        host: connectionOptions.host,
+        port: Number(connectionOptions.port) || 5432,
         username: connectionOptions.user,
         password: connectionOptions.password,
         database: connectionOptions.database,

--- a/src/ormconfig.ts
+++ b/src/ormconfig.ts
@@ -48,6 +48,12 @@ module.exports = [
         },
     },
     {
+        /*
+            "The idea with the testing configuration for TypeORM was so
+            that the testing could seed a database and integration test
+            with the database."
+                                                               -William
+        */
         name: 'testing',
         type: 'postgres',
         host: 'localhost',

--- a/src/ormconfig.ts
+++ b/src/ormconfig.ts
@@ -17,11 +17,11 @@ module.exports = [
         synchronize: true,
         logging: false,
         entities: [path.resolve(__dirname, 'database/entity/**/*.{ts,js}')],
-        migrations: [path.resolve(__dirname, 'database/migration/**/*.{ts,js}')],
+        migrations: [path.resolve(__dirname, 'database/migration/default/**/*.{ts,js}')],
         subscribers: [path.resolve(__dirname, 'database/subscriber/**/*.{ts,js}')],
         cli: {
             entitiesDir: path.relative('', path.resolve(__dirname, 'database/entity')),
-            migrationsDir: path.relative('', path.resolve(__dirname, 'database/migration')),
+            migrationsDir: path.relative('', path.resolve(__dirname, 'database/migration/default')),
             subscribersDir: path.relative('', path.resolve(__dirname, 'database/subscriber')),
         },
     },
@@ -36,11 +36,14 @@ module.exports = [
         synchronize: true,
         logging: false,
         entities: [path.resolve(__dirname, 'database/entity/**/*.{ts,js}')],
-        migrations: [path.resolve(__dirname, 'database/migration/**/*.{ts,js}')],
+        migrations: [path.resolve(__dirname, 'database/migration/development/**/*.{ts,js}')],
         subscribers: [path.resolve(__dirname, 'database/subscriber/**/*.{ts,js}')],
         cli: {
             entitiesDir: path.relative('', path.resolve(__dirname, 'database/entity')),
-            migrationsDir: path.relative('', path.resolve(__dirname, 'database/migration')),
+            migrationsDir: path.relative(
+                '',
+                path.resolve(__dirname, 'database/migration/development')
+            ),
             subscribersDir: path.relative('', path.resolve(__dirname, 'database/subscriber')),
         },
     },


### PR DESCRIPTION
# Description

Ensures the migrations for deployment/development are separated by their configuration files so seeds don't make it to production accidentally, requiring development teams to use `typeorm-dev migration:<cmd>` instead of `typeorm migration:<cmd>`

## Type of change

- [x] Accident protection
- [x] This change requires a documentation update

## Change Status

- [x] Complete, but not tested
